### PR TITLE
PE-29736 Updates for puppet6

### DIFF
--- a/lib/puppet/application/bootstrap.rb
+++ b/lib/puppet/application/bootstrap.rb
@@ -12,7 +12,8 @@ class Puppet::Application::Bootstrap < Puppet::Application::FaceBase
 
   def setup
     super
-    Puppet::SSL::Host.ca_location = :none
+
+    Puppet::SSL::Host.ca_location = :none if Gem::Version.new(Puppet.version) < Gem::Version.new('6.0')
     Puppet.settings.preferred_run_mode = "agent"
     Puppet.settings.use(:ssl)
   end


### PR DESCRIPTION
puppet ssl workflows are changed in puppet6. Most of the 'puppet cert'
commands are now replaced with 'puppetserver ca' commands and some of
the Puppet::SSL classes are deprecated in puppet6. This change adds a
generate_csr and purge_certs metghods to work with puppet6