### PR TITLE
Fix User Data Bootstrapping on AWS when using short_name in extension_requests

### DIFF
--- a/lib/puppet/application/bootstrap.rb
+++ b/lib/puppet/application/bootstrap.rb
@@ -1,4 +1,5 @@
 require 'puppet/application/face_base'
+require 'puppet/ssl/oids'
 
 class Puppet::Application::Bootstrap < Puppet::Application::FaceBase
   def app_defaults
@@ -13,6 +14,7 @@ class Puppet::Application::Bootstrap < Puppet::Application::FaceBase
   def setup
     super
 
+    Puppet::SSL::Oids.register_puppet_oids
     Puppet::SSL::Host.ca_location = :none if Gem::Version.new(Puppet.version) < Gem::Version.new('6.0')
     Puppet.settings.preferred_run_mode = "agent"
     Puppet.settings.use(:ssl)


### PR DESCRIPTION
Fix user-data bootstrapping on AWS with Puppet Enterprise (v2019.8.5) and Puppet (6.21.1)

This error occurs when using short_names in your CSR.
Resolves this error: `Error: Cannot create CSR with extension request pp_role: OBJ_txt2obj: first num too large`

```
extension_requests:
  1.3.6.1.4.1.34380.1.1.2: 'i-0835a58222aXXXXXX'
  1.3.6.1.4.1.34380.1.1.18: 'us-east-1'
  1.3.6.1.4.1.34380.1.1.3: 'ami-04d29b6f966df1537'
  pp_role: 'webserver'
```

Will always fail with the above error without this fix.

```
extension_requests:
  1.3.6.1.4.1.34380.1.1.2: 'i-0835a58222aXXXXXX'
  1.3.6.1.4.1.34380.1.1.18: 'us-east-1'
  1.3.6.1.4.1.34380.1.1.3: 'ami-04d29b6f966df1537'
```
If using the proper Numeric ID only then this will continue to work as expected. 

https://puppet.com/docs/puppet/6.21/ssl_attributes_extensions.html
https://tickets.puppetlabs.com/browse/PUP-9746

Note: Haven't touched Ruby in ages so don't know if this code is correct, but it does fix what is a blocking issue for any users running Puppet Enterprise on AWS, once this is fixed users will have to update their user-data scripts to pull the latest version. 